### PR TITLE
Add dual-backlog options doc for team discussion

### DIFF
--- a/docs/dual-backlog-options.md
+++ b/docs/dual-backlog-options.md
@@ -1,0 +1,112 @@
+# Dual Backlog: GitHub Issues + Jira — Options
+
+**Date:** 2026-03-25
+**Author:** Ed-Fi Product Management
+
+## Background
+
+Ed-Fi Alliance manages software development for several enterprise-grade open source tools serving the U.S. K-12 education community. The primary tool is the **Ed-Fi API**, a central interoperability hub for collecting and sharing data across disparate education systems.
+
+The software community includes three groups:
+- **System administrators** — run the Ed-Fi API and related applications
+- **System integrators** — contracted to install or operate software on behalf of education organizations
+- **API clients** — push or pull data via the Ed-Fi API
+
+When migrating from Jira Data Center (self-hosted) to Jira Cloud, it became cost-prohibitive to give all community members access. Development work continues in Jira, but there is no community visibility into bugs or feature requests.
+
+## Proposed Solution
+
+Use **two backlogs** with distinct purposes:
+
+| Backlog | Tool | Audience | Granularity |
+|---|---|---|---|
+| **Product backlog** | GitHub Issues | Staff, contractors, and eventually the broader community | High-level: bugs and feature requests |
+| **Release backlog** | Jira | Staff and contractors only | Fine-grained: tasks, technical debt, research spikes |
+
+### What goes in GitHub Issues
+
+- Bugs reported by community members
+- Bugs discovered internally that need community feedback
+- New feature requests (product-level, not implementation detail)
+
+### What stays in Jira only
+
+- Technical tasks and subtasks
+- Technical debt
+- Research spikes
+- Implementation-level detail
+
+### Where GitHub Issues will live
+
+To be decided. Options include:
+- **Centralized** — all issues in this `Technology-Roadmap` repository (current pattern for features and releases)
+- **Distributed** — bugs in each product's own repository, features in `Technology-Roadmap`
+
+## Automation Approaches
+
+The key challenge is keeping both backlogs in sync without duplicating effort. Three options are proposed, from most to least automated.
+
+---
+
+### Option A: Label-triggered full automation
+
+When a specific label (e.g., `scheduled`) is applied to a GitHub Issue, a GitHub Action automatically:
+1. Creates a corresponding Jira ticket
+2. Posts the Jira ticket link as a comment on the GitHub Issue
+3. Applies an `in-jira` label to the issue
+
+When the Jira ticket is resolved, a Jira webhook triggers a GitHub Action that closes the GitHub Issue.
+
+**Pros:**
+- Minimal manual steps end-to-end
+- Clear, visible state machine for community members
+
+**Cons:**
+- Requires strict label discipline — accidental label application creates unwanted Jira tickets
+- More complex to build and maintain
+- Better suited after workflow norms are established
+
+---
+
+### Option B: Manual Jira creation, automated sync back *(recommended starting point)*
+
+Staff manually create the Jira ticket when a GitHub Issue is picked up for a release, and paste the Jira link into the GitHub Issue. From there, automation takes over:
+
+- A GitHub Action monitors a Jira webhook
+- When the Jira ticket resolves, the GitHub Issue is automatically closed (optionally with a closing comment)
+
+**Pros:**
+- PM retains full control over what enters the Jira release backlog
+- Automation is simpler and one-directional
+- No risk of accidental ticket creation
+- Easier to establish good norms before opening issues to the broader community
+
+**Cons:**
+- One manual step per issue: creating the Jira ticket and pasting the link
+
+---
+
+### Option C: Manual everything, Jira native integration only
+
+Rely on Jira's native GitHub integration for linking PRs and commits. Staff manually update GitHub Issue labels to communicate status and manually close issues when work ships.
+
+**Pros:**
+- Nothing to build or break
+
+**Cons:**
+- High manual toil
+- High risk of GitHub Issues going stale
+- Does not scale as community grows
+
+---
+
+## Recommendation
+
+Start with **Option B**. It delivers most of the automation value with a fraction of the complexity. Once label taxonomy and workflow norms are established — and especially before opening issue creation to the broader community — the team can evolve toward Option A's label-triggered Jira ticket creation.
+
+## Open Questions
+
+- Where will GitHub Issues live? (centralized vs. distributed by product)
+- What labels are needed to represent issue lifecycle states?
+- Should GitHub Issues eventually be open to community members to file directly?
+- What comment or notification should be posted when a GitHub Issue is auto-closed?

--- a/docs/superpowers/specs/2026-03-26-dual-backlog-design.md
+++ b/docs/superpowers/specs/2026-03-26-dual-backlog-design.md
@@ -1,0 +1,179 @@
+# Dual Backlog Design: GitHub Issues + Jira (Option A)
+
+**Date:** 2026-03-26
+**Author:** Ed-Fi Product Management
+**Status:** Draft — pending implementation planning
+
+## Overview
+
+Ed-Fi Alliance manages software development for several enterprise-grade open source tools serving the U.S. K-12 education community. Following a migration from self-hosted Jira Data Center to Jira Cloud, the broader software community (system administrators, system integrators, API clients) lost visibility into bugs and feature requests.
+
+This design establishes a dual-backlog system:
+
+| Backlog | Tool | Audience | Purpose |
+|---|---|---|---|
+| **Product backlog** | GitHub Issues | Staff, contractors (community eventually) | High-level bugs and feature requests |
+| **Release backlog** | Jira Cloud | Staff and contractors only | Fine-grained tasks, technical debt, spikes |
+
+## Scope
+
+### What belongs in GitHub Issues
+
+- Bugs reported by community members
+- Bugs discovered internally that need community feedback or visibility
+- New feature requests at the product level
+
+### What stays in Jira only
+
+- Technical subtasks and implementation detail
+- Technical debt
+- Research spikes
+- Release planning artifacts
+
+### Where GitHub Issues will live
+
+To be decided: either centralized in this `Technology-Roadmap` repository or distributed across individual product repositories. The design works in either location.
+
+---
+
+## Label Schema
+
+Every GitHub Issue is labeled across three dimensions.
+
+### Type labels
+Determine the Jira issue type created during promotion.
+
+| Label | Jira Issue Type |
+|---|---|
+| `bug` | Bug |
+| `feature` | Story |
+
+### Lifecycle labels
+Reflect where the issue is in the pipeline. `triaged` and `scheduled` are applied by humans; `in-jira` is applied by automation but may also be applied manually (see below).
+
+| Label | Meaning |
+|---|---|
+| `triaged` | Staff has reviewed and confirmed the issue is valid |
+| `scheduled` | PM has approved this for Jira promotion — trigger label |
+| `in-jira` | A Jira ticket exists for this issue |
+
+**Manual use of `in-jira`:** Staff may apply this label directly when linking a GitHub Issue to a pre-existing Jira ticket, skipping the automated promotion flow. In this case, staff should also post a comment with the Jira ticket URL.
+
+### Jira routing labels
+Determine which Jira project the ticket is created in. One per issue.
+
+| Label | Jira Project |
+|---|---|
+| `jira-ods` | ODS |
+| `jira-ac` | AC |
+| *(additional labels added as Jira projects are onboarded)* | |
+
+> **Note:** The existing product area labels (`ods-api-platform`, `dms-platform`, `data-standard`, `data-mgmt-tools`) are not used for automation routing and should be evaluated for retirement or repurposed for community-facing categorization only.
+
+---
+
+## Workflow
+
+### 1. Creation
+
+Staff opens a GitHub Issue using the `bug` or `feature` template and applies:
+- The appropriate type label (`bug` or `feature`)
+- The appropriate Jira routing label (`jira-*`)
+
+### 2. Triage
+
+Staff reviews the issue and applies `triaged` if it is valid and worth tracking. Issues may remain in this state indefinitely — the GitHub product backlog has no time pressure.
+
+### 3. Scheduling → Jira promotion (automated)
+
+When the PM is ready to schedule work for a release, they apply the `scheduled` label.
+
+The "Promote to Jira" GitHub Action fires when it detects that an issue has **both** `scheduled` and a `jira-*` label. The action:
+1. Creates a Jira ticket in the correct project with the correct issue type
+2. Posts a comment on the GitHub Issue with the new Jira ticket URL
+3. Applies `in-jira` to the GitHub Issue
+4. Removes `scheduled` from the GitHub Issue (prevents re-triggering)
+
+### 4. Manual back-linking (alternative to step 3)
+
+If a Jira ticket already exists for the GitHub Issue, staff skip step 3 and instead:
+- Apply `in-jira` manually
+- Post a comment on the GitHub Issue with the Jira ticket URL
+
+### 5. Active work
+
+The Jira ticket drives release backlog work. The GitHub Issue remains open and publicly visible, with the Jira link in the comments.
+
+### 6. Resolution (automated)
+
+When the Jira ticket is marked Done, a Jira webhook triggers the "Close from Jira" GitHub Action, which:
+1. Posts a comment on the GitHub Issue: *"This has been resolved and will be included in an upcoming release."*
+2. Closes the GitHub Issue
+
+---
+
+## Automation Architecture
+
+### Action 1: Promote to Jira
+
+| Property | Value |
+|---|---|
+| **Trigger** | `issues` event, `labeled` action |
+| **Guard** | Issue must have both `scheduled` AND a `jira-*` label at time of event |
+
+**Steps:**
+1. Read issue title, body, type label, and `jira-*` label
+2. Resolve Jira project from `jira-*` label
+3. Resolve Jira issue type: `bug` → Bug, `feature` → Story
+4. Call Jira REST API to create ticket:
+   - Summary ← GitHub Issue title
+   - Description ← GitHub Issue body + GitHub Issue URL in footer
+   - Create a Jira Remote Link pointing to the GitHub Issue URL
+5. Post comment on GitHub Issue with the new Jira ticket URL
+6. Apply `in-jira` label; remove `scheduled` label
+
+### Action 2: Close from Jira
+
+| Property | Value |
+|---|---|
+| **Trigger** | `repository_dispatch` event, fired by Jira webhook on ticket transition to Done |
+
+**Steps:**
+1. Parse the GitHub Issue URL from the Jira webhook payload (sourced from the Remote Link stored during creation)
+2. Post comment: *"This has been resolved and will be included in an upcoming release."*
+3. Close the GitHub Issue
+
+### Required secrets
+
+| Secret | Purpose |
+|---|---|
+| `JIRA_API_TOKEN` | Jira Cloud access token |
+| `JIRA_BASE_URL` | Jira Cloud instance URL |
+| `JIRA_USER_EMAIL` | Account used for Jira API calls |
+| `GITHUB_TOKEN` | Write access to GitHub Issues (built-in for same-repo actions; PAT if cross-repo) |
+
+---
+
+## Data Mapping: GitHub Issue → Jira Ticket
+
+| GitHub Issue field | Jira Ticket field |
+|---|---|
+| Title | Summary |
+| Body | Description |
+| `bug` label | Issue Type: Bug |
+| `feature` label | Issue Type: Story |
+| `jira-ods` label | Project: ODS |
+| `jira-ac` label | Project: AC |
+| Issue URL | Remote Link + Description footer |
+
+Jira fields not sourced from GitHub (assignee, sprint, priority, story points) are set by the team inside Jira during release planning.
+
+---
+
+## Open Questions
+
+- Where will GitHub Issues live? (centralized in `Technology-Roadmap` vs. distributed per product repo)
+- Should the closing comment reference the specific release version once known?
+- Should the `triaged` step be enforced (i.e., block `scheduled` from being applied unless `triaged` is present), or left as a convention?
+- What should happen if both `bug` and `feature` labels are applied? (Guard or default behavior needed)
+- When will issue creation be opened to the broader community?

--- a/docs/superpowers/specs/2026-03-26-dual-backlog-design.md
+++ b/docs/superpowers/specs/2026-03-26-dual-backlog-design.md
@@ -30,6 +30,10 @@ This design establishes a dual-backlog system:
 - Research spikes
 - Release planning artifacts
 
+### Out of scope
+
+**Planned Release issues** (created via the `PLANNED-RELEASE.yml` template) are not part of the dual-backlog workflow. They are not promoted to Jira and are not affected by any automation described in this design. The `PLANNED-RELEASE.yml` template currently instructs staff to apply product area labels; that instruction will be removed as part of this work to keep templates consistent.
+
 ### Where GitHub Issues will live
 
 All GitHub Issues are centralized in the `Ed-Fi-Technology-Roadmap` repository. This provides a single collection point for community-facing visibility and, when the time comes, for community-submitted issues.
@@ -37,6 +41,15 @@ All GitHub Issues are centralized in the `Ed-Fi-Technology-Roadmap` repository. 
 **Future consideration:** After triage, staff may copy an issue from `Ed-Fi-Technology-Roadmap` into the relevant product-specific repository (e.g., `Ed-Fi-ODS`) to keep it close to the code. This option is not exercised at launch but is available without changes to the automation design.
 
 **Future consideration:** Direct issue creation by the broader community is planned but has no fixed timeline. The label schema and workflow described here are designed to accommodate community contributors without structural changes.
+
+### Implementation prerequisites
+
+The following items must be completed before the automation can be used:
+
+- **New `BUG.yml` issue template** — does not currently exist; must be created with fields: Steps to Reproduce, Expected Behavior, Actual Behavior, and Environment. It should auto-apply the `bug` label via the template `labels:` field.
+- **Update `PROPOSED-FEATURE.yml`** — add a `markdown` informational element prompting staff to apply the appropriate `jira-*` routing label after creation; remove the existing instruction referencing product area labels. The `jira-*` prompt is informational text, not a required form field — enforcement is handled by Action 1. The existing `labels: [feature]` auto-assignment is preserved.
+- **Update `PLANNED-RELEASE.yml`** — remove the instruction to apply product area labels.
+- **Create `GitHub Issue URL` custom field in Jira** — a one-time admin task; a plain text field used by Action 1 to store the GitHub Issue URL and by the Jira Automation rule to retrieve it. Must be created before any Jira tickets are promoted via the automation.
 
 ---
 
@@ -52,7 +65,9 @@ Determine the Jira issue type created during promotion.
 | `bug` | Bug |
 | `feature` | Story |
 
-If both `bug` and `feature` are applied to the same issue, the automation treats it as a `feature`.
+**Conflict and missing-label rules (enforced by Action 1):**
+- If both `bug` and `feature` are present: treat as `feature` (Story)
+- If neither is present: post an error comment, remove `scheduled`, and exit; the PM must add a type label before re-applying `scheduled`
 
 ### Lifecycle labels
 Reflect where the issue is in the pipeline. `triaged` and `scheduled` are applied by humans; `in-jira` is applied by automation but may also be applied manually (see below).
@@ -65,10 +80,12 @@ Reflect where the issue is in the pipeline. `triaged` and `scheduled` are applie
 
 **`triaged` is a convention, not enforced by automation.** Because only staff and contractors can currently create issues, the automation does not require `triaged` to be present before promotion. Staff are expected to apply it as part of their review workflow.
 
-**Manual use of `in-jira`:** Staff may apply this label directly when linking a GitHub Issue to a pre-existing Jira ticket, skipping the automated promotion flow. In this case, staff should also post a comment with the Jira ticket URL.
+**Manual use of `in-jira`:** Staff may apply this label directly when linking a GitHub Issue to a pre-existing Jira ticket, skipping the automated promotion flow. In this case, staff must also:
+- Post a comment on the GitHub Issue with the Jira ticket URL
+- Create a Remote Link on the Jira ticket pointing to the GitHub Issue URL (required for the Jira Automation rule to include the GitHub Issue URL in the close payload; see Action 2)
 
 ### Jira routing labels
-Determine which Jira project the ticket is created in. One per issue.
+Determine which Jira project the ticket is created in. Exactly one per issue.
 
 | Label | Jira Project |
 |---|---|
@@ -76,7 +93,11 @@ Determine which Jira project the ticket is created in. One per issue.
 | `jira-ac` | AC |
 | *(additional labels added as Jira projects are onboarded)* | |
 
-> **Note:** The existing product area labels (`ods-api-platform`, `dms-platform`, `data-standard`, `data-mgmt-tools`) are not used for automation routing and should be evaluated for retirement or repurposed for community-facing categorization only.
+**Routing label rules (enforced by Action 1):**
+- If no `jira-*` label is present when `scheduled` is applied: post an error comment, remove `scheduled`, and exit; the PM must add a routing label before re-applying `scheduled`
+- If more than one `jira-*` label is present: post an error comment, remove `scheduled`, and exit; the PM must remove the extra routing labels before re-applying `scheduled`
+
+> **Note:** The existing product area labels (`ods-api-platform`, `dms-platform`, `data-standard`, `data-mgmt-tools`) are not used for automation routing. The issue templates will be updated as part of implementation to prompt for `jira-*` routing labels and remove instructions referencing the product area labels.
 
 ---
 
@@ -84,19 +105,19 @@ Determine which Jira project the ticket is created in. One per issue.
 
 ### 1. Creation
 
-Staff opens a GitHub Issue using the `bug` or `feature` template and applies:
-- The appropriate type label (`bug` or `feature`)
-- The appropriate Jira routing label (`jira-*`)
+Staff opens a GitHub Issue using the `BUG.yml` or `PROPOSED-FEATURE.yml` template and applies:
+- The appropriate type label (`bug` or `feature`) — auto-applied by the template
+- The appropriate Jira routing label (`jira-*`) — prompted by the template
 
 ### 2. Triage
 
-Staff reviews the issue and applies `triaged` if it is valid and worth tracking. Issues may remain in this state indefinitely — the GitHub product backlog has no time pressure.
+Staff reviews the issue and applies `triaged` if it is valid and worth tracking. Issues may remain in this state indefinitely — the GitHub product backlog has no time pressure. `triaged` is a human convention; the automation does not depend on it.
 
 ### 3. Scheduling → Jira promotion (automated)
 
-When the PM is ready to schedule work for a release, they apply the `scheduled` label.
+When the PM is ready to schedule work for a release, they apply the `scheduled` label. The `jira-*` routing label may be applied before or after `scheduled` — the guard is evaluated against the full label set at event time, so both orderings trigger the action.
 
-The "Promote to Jira" GitHub Action fires when it detects that an issue has **both** `scheduled` and a `jira-*` label. The action:
+The "Promote to Jira" GitHub Action fires when an `issues` `labeled` event occurs and the issue has **`scheduled`** present and does **not** already have `in-jira`. The action validates routing and type labels internally and posts error comments if anything is missing. The action:
 1. Creates a Jira ticket in the correct project with the correct issue type
 2. Posts a comment on the GitHub Issue with the new Jira ticket URL
 3. Applies `in-jira` to the GitHub Issue
@@ -107,6 +128,7 @@ The "Promote to Jira" GitHub Action fires when it detects that an issue has **bo
 If a Jira ticket already exists for the GitHub Issue, staff skip step 3 and instead:
 - Apply `in-jira` manually
 - Post a comment on the GitHub Issue with the Jira ticket URL
+- Create a Remote Link on the Jira ticket pointing to the GitHub Issue URL
 
 ### 5. Active work
 
@@ -114,9 +136,9 @@ The Jira ticket drives release backlog work. The GitHub Issue remains open and p
 
 ### 6. Resolution (automated)
 
-When the Jira ticket is marked Done, a Jira webhook triggers the "Close from Jira" GitHub Action, which:
+When the Jira ticket is marked Done, a Jira Automation rule triggers the "Close from Jira" GitHub Action, which:
 1. Posts a comment on the GitHub Issue referencing the release version (see Action 2 below)
-2. Closes the GitHub Issue
+2. Closes the GitHub Issue as completed
 
 ---
 
@@ -127,41 +149,75 @@ When the Jira ticket is marked Done, a Jira webhook triggers the "Close from Jir
 | Property | Value |
 |---|---|
 | **Trigger** | `issues` event, `labeled` action |
-| **Guard** | Issue must have both `scheduled` AND a `jira-*` label at time of event |
+| **Guard** | Issue must have `scheduled` AND must NOT have `in-jira` at time of event |
+
+The guard omits the `jira-*` requirement so that applying `scheduled` before a routing label is present will still trigger the action and surface a user-facing error (Step 2 below), rather than silently doing nothing.
 
 **Steps:**
-1. Read issue title, body, type label, and `jira-*` label
-2. Resolve Jira project from `jira-*` label
-3. Resolve Jira issue type: `feature` → Story, `bug` → Bug; if both type labels are present, use Story
-4. Call Jira REST API to create ticket:
+1. Confirm the issue does not have `in-jira`. If it does, exit without action.
+2. Validate routing labels: if no `jira-*` label is present, post error comment *"This issue cannot be promoted to Jira because it has no routing label (`jira-*`). Please add one and re-apply `scheduled`."*, remove `scheduled`, and exit. If more than one `jira-*` label is present, post error comment *"This issue cannot be promoted to Jira because it has more than one routing label. Please remove the extra `jira-*` label and re-apply `scheduled`."*, remove `scheduled`, and exit.
+3. Validate type labels: if neither `bug` nor `feature` is present, post error comment *"This issue cannot be promoted to Jira because it has no type label (`bug` or `feature`). Please add one and re-apply `scheduled`."*, remove `scheduled`, and exit.
+4. Resolve Jira project from the single `jira-*` label
+5. Resolve Jira issue type: `feature` → Story, `bug` → Bug; if both type labels are present, use Story
+6. Call Jira REST API v3 to create ticket:
    - Summary ← GitHub Issue title
-   - Description ← GitHub Issue body + GitHub Issue URL in footer
-   - Create a Jira Remote Link pointing to the GitHub Issue URL
-5. Post comment on GitHub Issue with the new Jira ticket URL
-6. Apply `in-jira` label; remove `scheduled` label
+   - Description ← two ADF `paragraph` nodes: the first containing a `text` node with the raw GitHub Issue body (Markdown passed through as-is; no conversion), the second containing a `text` node with `GitHub Issue: <URL>`
+   - `GitHub Issue URL` custom field ← GitHub Issue URL (see note below)
+   - If the Jira API call fails: post error comment *"Jira ticket creation failed. Please try again or create the Jira ticket manually."*, remove `scheduled`, and exit.
+7. Call Jira REST API v3 to create a Remote Link on the new ticket (`POST /rest/api/3/issue/{key}/remotelink`) with title "GitHub Issue" and the GitHub Issue URL. If this call fails, log the error but continue — the ticket was already created. Staff will need to add the Remote Link manually.
+
+> **Note — `GitHub Issue URL` custom field:** The Jira Automation rule in Action 2 needs to read the GitHub Issue URL from the Jira ticket. Jira Automation smart value support for Remote Link URLs is not guaranteed on all Jira Cloud tiers. To ensure reliability, a custom text field named `GitHub Issue URL` must be created in Jira (a one-time admin task) and populated by Action 1 at ticket creation time. The Jira Automation rule reads from this field. If the custom field is not created, verify during implementation that `{{issue.remoteLinks}}` smart value filtering by title is available on the target Jira Cloud instance before falling back to the Remote Link approach.
+8. Post comment on GitHub Issue with the new Jira ticket URL
+9. Apply `in-jira` label; remove `scheduled` label
 
 ### Action 2: Close from Jira
 
 | Property | Value |
 |---|---|
-| **Trigger** | `repository_dispatch` event, fired by Jira webhook on ticket transition to Done |
+| **Trigger** | `repository_dispatch` event with `event_type: jira-issue-done`, fired by a Jira Automation rule on ticket transition to Done |
+
+**Jira Automation rule configuration:** A Jira Automation rule (not a native webhook) must be configured to fire when an issue transitions to the Done status. The rule sends an HTTP POST request to the GitHub API `repository_dispatch` endpoint with a JSON body constructed from the Jira issue's fields. Native Jira webhooks do not support custom payload construction and cannot be used here.
+
+The rule must extract:
+- `github_issue_url` from the `GitHub Issue URL` custom field on the Jira ticket (populated by Action 1; also manually populated during back-linking)
+- `fix_version` from the Jira ticket's Fix Version field (may be empty)
+
+**Expected payload structure:**
+
+```json
+{
+  "event_type": "jira-issue-done",
+  "client_payload": {
+    "github_issue_url": "https://github.com/Ed-Fi-Alliance-OSS/Ed-Fi-Technology-Roadmap/issues/123",
+    "fix_version": "v4.2"
+  }
+}
+```
+
+`fix_version` may be `null` or absent if no Fix Version is set on the Jira ticket.
 
 **Steps:**
-1. Parse the GitHub Issue URL from the Jira webhook payload (sourced from the Remote Link stored during creation)
-2. Parse the Fix Version from the Jira webhook payload
-3. Post comment:
-   - If Fix Version is present: *"This has been resolved and will be included in release \<version\>."*
-   - If Fix Version is absent: *"This has been resolved and will be included in an upcoming release."*
-4. Close the GitHub Issue
+1. Parse `github_issue_url` from the `client_payload` in the `repository_dispatch` event
+2. If `github_issue_url` is absent or unparseable: log the error and exit without taking action
+3. Check whether the GitHub Issue is already closed. If it is, exit without action.
+4. Parse `fix_version` from `client_payload`
+5. Post comment:
+   - If `fix_version` is present: *"This has been resolved and will be included in release \<version\>."*
+   - If `fix_version` is absent or null: *"This has been resolved and will be included in an upcoming release."*
+6. Close the GitHub Issue as completed (GitHub API `state_reason: completed`)
 
 ### Required secrets
+
+Since all issues live in `Ed-Fi-Technology-Roadmap` and both actions run in the same repository, the built-in `GITHUB_TOKEN` is sufficient for GitHub API calls at launch.
 
 | Secret | Purpose |
 |---|---|
 | `JIRA_API_TOKEN` | Jira Cloud access token |
 | `JIRA_BASE_URL` | Jira Cloud instance URL |
 | `JIRA_USER_EMAIL` | Account used for Jira API calls |
-| `GITHUB_TOKEN` | Write access to GitHub Issues (built-in for same-repo actions; PAT if cross-repo) |
+| `GITHUB_TOKEN` | Write access to GitHub Issues (built-in) |
+
+**Future consideration:** If issues are ever copied to product-specific repositories and the actions need to close issues in those repos, a PAT with cross-repo write access will be required in place of the built-in token.
 
 ---
 
@@ -170,12 +226,14 @@ When the Jira ticket is marked Done, a Jira webhook triggers the "Close from Jir
 | GitHub Issue field | Jira Ticket field |
 |---|---|
 | Title | Summary |
-| Body | Description |
+| Body | Description — ADF paragraph node, `text` node containing raw Markdown (not converted) |
+| — | Description second paragraph: `GitHub Issue: <URL>` |
+| Issue URL | `GitHub Issue URL` custom field |
 | `bug` label (sole type label) | Issue Type: Bug |
 | `feature` label (or both type labels present) | Issue Type: Story |
 | `jira-ods` label | Project: ODS |
 | `jira-ac` label | Project: AC |
-| Issue URL | Remote Link + Description footer |
+| Issue URL | Remote Link (title: "GitHub Issue") |
 
 Jira fields not sourced from GitHub (assignee, sprint, priority, story points) are set by the team inside Jira during release planning.
 
@@ -183,11 +241,12 @@ Jira fields not sourced from GitHub (assignee, sprint, priority, story points) a
 
 | Jira Ticket field | GitHub Issue |
 |---|---|
-| Remote Link URL | Identifies the GitHub Issue to close |
-| Fix Version (if set) | Referenced in closing comment |
+| `GitHub Issue URL` custom field | Source of `github_issue_url` in Jira Automation rule payload |
+| Fix Version (if set) | Source of `fix_version` in Jira Automation rule payload; referenced in closing comment |
 
 ---
 
 ## Open Questions
 
 - When community issue creation is enabled, should it be gated on a label-based permission check or simply opened to all GitHub users?
+- When community issue creation is enabled, should `triaged` become a required guard condition before `scheduled` can trigger Jira promotion?

--- a/docs/superpowers/specs/2026-03-26-dual-backlog-design.md
+++ b/docs/superpowers/specs/2026-03-26-dual-backlog-design.md
@@ -103,6 +103,34 @@ Determine which Jira project the ticket is created in. Exactly one per issue.
 
 ## Workflow
 
+```mermaid
+flowchart TD
+    A([Staff creates GitHub Issue\nbug or feature template]) --> B[Apply type label\nbug or feature]
+    B --> C[Apply jira-* routing label]
+    C --> D[Staff reviews issue]
+    D --> E{Valid?}
+    E -- No --> F([Issue closed or ignored])
+    E -- Yes --> G[Apply triaged label\nconvention only]
+    G --> H{Jira ticket\nalready exists?}
+
+    H -- Yes\nManual back-linking --> I[Apply in-jira manually\nPost Jira URL comment\nCreate Jira Remote Link]
+    I --> J
+
+    H -- No --> K[PM applies scheduled label]
+    K --> L{Validation\npasses?}
+    L -- Missing or duplicate\nrouting/type label --> M[Error comment posted\nscheduled removed]
+    M --> K
+    L -- Yes --> N[Action 1: Promote to Jira\nCreate Jira ticket\nPost Jira URL comment\nApply in-jira, remove scheduled]
+
+    N --> J([Jira ticket drives\nrelease backlog work\nGitHub Issue remains open])
+
+    J --> O{Jira ticket\nmarked Done?}
+    O -- No --> J
+    O -- Yes --> P[Jira Automation rule fires\nrepository_dispatch to GitHub]
+    P --> Q[Action 2: Close from Jira\nPost resolution comment\nClose GitHub Issue as completed]
+    Q --> R([GitHub Issue closed])
+```
+
 ### 1. Creation
 
 Staff opens a GitHub Issue using the `BUG.yml` or `PROPOSED-FEATURE.yml` template and applies:

--- a/docs/superpowers/specs/2026-03-26-dual-backlog-design.md
+++ b/docs/superpowers/specs/2026-03-26-dual-backlog-design.md
@@ -32,7 +32,11 @@ This design establishes a dual-backlog system:
 
 ### Where GitHub Issues will live
 
-To be decided: either centralized in this `Technology-Roadmap` repository or distributed across individual product repositories. The design works in either location.
+All GitHub Issues are centralized in the `Ed-Fi-Technology-Roadmap` repository. This provides a single collection point for community-facing visibility and, when the time comes, for community-submitted issues.
+
+**Future consideration:** After triage, staff may copy an issue from `Ed-Fi-Technology-Roadmap` into the relevant product-specific repository (e.g., `Ed-Fi-ODS`) to keep it close to the code. This option is not exercised at launch but is available without changes to the automation design.
+
+**Future consideration:** Direct issue creation by the broader community is planned but has no fixed timeline. The label schema and workflow described here are designed to accommodate community contributors without structural changes.
 
 ---
 
@@ -48,6 +52,8 @@ Determine the Jira issue type created during promotion.
 | `bug` | Bug |
 | `feature` | Story |
 
+If both `bug` and `feature` are applied to the same issue, the automation treats it as a `feature`.
+
 ### Lifecycle labels
 Reflect where the issue is in the pipeline. `triaged` and `scheduled` are applied by humans; `in-jira` is applied by automation but may also be applied manually (see below).
 
@@ -56,6 +62,8 @@ Reflect where the issue is in the pipeline. `triaged` and `scheduled` are applie
 | `triaged` | Staff has reviewed and confirmed the issue is valid |
 | `scheduled` | PM has approved this for Jira promotion — trigger label |
 | `in-jira` | A Jira ticket exists for this issue |
+
+**`triaged` is a convention, not enforced by automation.** Because only staff and contractors can currently create issues, the automation does not require `triaged` to be present before promotion. Staff are expected to apply it as part of their review workflow.
 
 **Manual use of `in-jira`:** Staff may apply this label directly when linking a GitHub Issue to a pre-existing Jira ticket, skipping the automated promotion flow. In this case, staff should also post a comment with the Jira ticket URL.
 
@@ -107,7 +115,7 @@ The Jira ticket drives release backlog work. The GitHub Issue remains open and p
 ### 6. Resolution (automated)
 
 When the Jira ticket is marked Done, a Jira webhook triggers the "Close from Jira" GitHub Action, which:
-1. Posts a comment on the GitHub Issue: *"This has been resolved and will be included in an upcoming release."*
+1. Posts a comment on the GitHub Issue referencing the release version (see Action 2 below)
 2. Closes the GitHub Issue
 
 ---
@@ -124,7 +132,7 @@ When the Jira ticket is marked Done, a Jira webhook triggers the "Close from Jir
 **Steps:**
 1. Read issue title, body, type label, and `jira-*` label
 2. Resolve Jira project from `jira-*` label
-3. Resolve Jira issue type: `bug` → Bug, `feature` → Story
+3. Resolve Jira issue type: `feature` → Story, `bug` → Bug; if both type labels are present, use Story
 4. Call Jira REST API to create ticket:
    - Summary ← GitHub Issue title
    - Description ← GitHub Issue body + GitHub Issue URL in footer
@@ -140,8 +148,11 @@ When the Jira ticket is marked Done, a Jira webhook triggers the "Close from Jir
 
 **Steps:**
 1. Parse the GitHub Issue URL from the Jira webhook payload (sourced from the Remote Link stored during creation)
-2. Post comment: *"This has been resolved and will be included in an upcoming release."*
-3. Close the GitHub Issue
+2. Parse the Fix Version from the Jira webhook payload
+3. Post comment:
+   - If Fix Version is present: *"This has been resolved and will be included in release \<version\>."*
+   - If Fix Version is absent: *"This has been resolved and will be included in an upcoming release."*
+4. Close the GitHub Issue
 
 ### Required secrets
 
@@ -160,20 +171,23 @@ When the Jira ticket is marked Done, a Jira webhook triggers the "Close from Jir
 |---|---|
 | Title | Summary |
 | Body | Description |
-| `bug` label | Issue Type: Bug |
-| `feature` label | Issue Type: Story |
+| `bug` label (sole type label) | Issue Type: Bug |
+| `feature` label (or both type labels present) | Issue Type: Story |
 | `jira-ods` label | Project: ODS |
 | `jira-ac` label | Project: AC |
 | Issue URL | Remote Link + Description footer |
 
 Jira fields not sourced from GitHub (assignee, sprint, priority, story points) are set by the team inside Jira during release planning.
 
+## Data Mapping: Jira Ticket → GitHub Issue (on close)
+
+| Jira Ticket field | GitHub Issue |
+|---|---|
+| Remote Link URL | Identifies the GitHub Issue to close |
+| Fix Version (if set) | Referenced in closing comment |
+
 ---
 
 ## Open Questions
 
-- Where will GitHub Issues live? (centralized in `Technology-Roadmap` vs. distributed per product repo)
-- Should the closing comment reference the specific release version once known?
-- Should the `triaged` step be enforced (i.e., block `scheduled` from being applied unless `triaged` is present), or left as a convention?
-- What should happen if both `bug` and `feature` labels are applied? (Guard or default behavior needed)
-- When will issue creation be opened to the broader community?
+- When community issue creation is enabled, should it be gated on a label-based permission check or simply opened to all GitHub users?


### PR DESCRIPTION
Captures the background, proposed GitHub Issues + Jira split, and three automation approach options (with recommendation) for review.