### PR TITLE
Fix GraphQL query in Jira ticket workflow (missing nodes wrapper)

### DIFF
--- a/.github/workflows/jira-create-ticket.yml
+++ b/.github/workflows/jira-create-ticket.yml
@@ -154,6 +154,7 @@ jobs:
               query($owner: String!, $repo: String!, $issueId: ID!) {
                 repository(owner: $owner, name: $repo) {
                   issueFields(first: 100) {
+                    nodes {
                       __typename
                       ... on IssueFieldText { id name }
                     }
@@ -162,6 +163,7 @@ jobs:
                 node(id: $issueId) {
                   ... on Issue {
                     issueFieldValues(first: 100) {
+                      nodes {
                         __typename
                         ... on IssueFieldTextValue {
                           value


### PR DESCRIPTION
## Problem

The `Create Jira Ticket from GitHub Label` workflow was failing at the **Check for existing Jira ticket for this project** step (e.g. run `29536948532`) with a GraphQL parse error:

```
Expected one of SCHEMA, SCALAR, TYPE, ENUM, INPUT, UNION, INTERFACE, actual: IDENTIFIER ("node") at [10, 5]
```

## Root cause

The `issueFields` and `issueFieldValues` connections in the `github.graphql(...)` query were missing their required `nodes { }` selection wrapper. Without that wrapper the query's braces were off by one, so a closing brace prematurely terminated the `query` operation and the parser hit `node(id: $issueId)` at the top level of the document — where it expects a schema/type-system keyword, not a field.

This is purely a malformed-query bug; it fails before any Jira/auth logic runs. No secrets or Actions variables are involved.

## Fix

Re-add the `nodes { }` wrapper to both connections. The JavaScript that consumes the result already reads `result.repository.issueFields.nodes` and `result.node.issueFieldValues.nodes`, so this restores the query to match the code (and the previously-working version).

Verified locally: query brace balance is 0 and never goes negative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)