### PR TITLE
[AI-163] Convert GitHub issue Markdown to ADF for Jira description

### DIFF
--- a/.github/workflows/jira-create-ticket.yml
+++ b/.github/workflows/jira-create-ticket.yml
@@ -224,11 +224,37 @@ jobs:
           ISSUE_TITLE:      ${{ github.event.issue.title }}
           ISSUE_BODY:       ${{ github.event.issue.body }}
         run: |
+          # Jira Cloud's REST API requires the description in Atlassian Document Format (ADF);
+          # it does NOT render Markdown. GitHub issue bodies are GitHub-flavored Markdown, so
+          # convert them to ADF with marklassian — otherwise headings, lists, code blocks and
+          # links land as a single unformatted plain-text blob (AI-163).
+          npm install marklassian@1.2.1 --no-save --no-audit --no-fund --silent
+
+          # Dynamic import() so this works whether marklassian resolves as CommonJS or ESM.
+          node --input-type=module -e '
+            const { markdownToAdf } = await import("marklassian");
+            const fs = await import("node:fs");
+            const md = process.env.ISSUE_BODY || "";
+            let adf;
+            try {
+              adf = markdownToAdf(md);
+            } catch (err) {
+              // Never fail ticket creation on odd Markdown — fall back to a plain-text paragraph.
+              adf = { version: 1, type: "doc",
+                content: [{ type: "paragraph", content: [{ type: "text", text: md || "(no description provided)" }] }] };
+            }
+            // Jira rejects an empty doc; emit an empty paragraph for bodyless issues.
+            if (!adf.content || adf.content.length === 0) {
+              adf = { version: 1, type: "doc", content: [{ type: "paragraph" }] };
+            }
+            fs.writeFileSync("description.adf.json", JSON.stringify(adf));
+          '
+
           PAYLOAD=$(jq -n \
             --arg summary     "${ISSUE_TITLE}" \
             --arg project     "${JIRA_PROJECT_KEY}" \
             --arg issuetype   "${JIRA_ISSUE_TYPE}" \
-            --arg description "${ISSUE_BODY}" \
+            --slurpfile description description.adf.json \
             --arg assignee    "${JIRA_ASSIGNEE_ID}" \
             --arg sprint      "${JIRA_SPRINT_ID}" \
             --argjson labels  "${JIRA_LABELS:-[]}" \
@@ -237,12 +263,7 @@ jobs:
                 project:     { key: $project },
                 summary:     $summary,
                 issuetype:   { name: $issuetype },
-                description: {
-                  type: "doc", version: 1,
-                  content: [{ type: "paragraph",
-                    content: [{ type: "text", text: $description }]
-                  }]
-                }
+                description: $description[0]
               }
             }
             | if $assignee != "" then .fields.assignee = { accountId: $assignee } else . end


### PR DESCRIPTION
## Summary

Fixes **AI-163** — GitHub issue bodies were rendering as a single unformatted plain-text blob in the Jira tickets created by this workflow.

**Root cause:** Jira Cloud's REST API accepts descriptions only in Atlassian Document Format (ADF), not Markdown. The `Create Jira Ticket` step was wrapping the raw issue body in a single ADF `text` node, so all Markdown structure (headings, lists, links, code blocks) was lost.

> Note: the ticket suggested switching from the REST API to `acli`. Atlassian's docs confirm `acli`'s `--description`/`--description-file` also accept only "plain text or ADF" (no Markdown, no auto-conversion), so that swap would not have fixed rendering. The real fix is converting Markdown → ADF, which this PR does while keeping the existing REST transport (no new CI auth required).

## Change

In the `Create Jira Ticket` step:
- `npm install marklassian@1.2.1` and convert the issue body (GitHub-flavored Markdown) → ADF via a small Node script (dynamic `import()` so it works whether the package resolves as CommonJS or ESM).
- Feed the resulting ADF into the payload with `jq --slurpfile`.
- Fallbacks: conversion error → plain-text paragraph; empty/whitespace body → empty paragraph (Jira rejects an empty doc).

## Testing

Verified in the `Automation-Testing` sandbox repo: labeled an issue with a Markdown-rich body (heading, bold, link, bullet list, fenced code block) and confirmed the created Jira ticket rendered them as formatted ADF. Conversion, payload build, edge cases (empty/whitespace/plain-text), and workflow YAML parsing were also validated locally.

## Notes

- Adds a runtime `npm install marklassian` (network access at job time) to the create step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)