### PR TITLE
[AI-194] Harden dev-backlog workflow: pin github-script to v9, loop guard, green-run skips, job summary

### DIFF
--- a/.github/workflows/github-to-jira-dev-backlog.yml
+++ b/.github/workflows/github-to-jira-dev-backlog.yml
@@ -1,4 +1,4 @@
-name: Create Jira Ticket from GitHub Label
+name: Labelled issue → Jira dev backlog
 
 on:
   issues:
@@ -7,10 +7,15 @@ on:
 permissions:
   issues: write
 jobs:
-  create-jira-ticket:
+  github-to-jira-dev-backlog:
     # Run on every label event — the first step determines if this label is a configured trigger
     if: vars.GH_JIRA_AUTOMATION_CONFIG != ''
     runs-on: ubuntu-latest
+    # Fail fast instead of occupying a runner for the 6-hour default. This job has more hang
+    # surface than its siblings: a runtime `npm install` plus two curls to Jira. Because
+    # cancel-in-progress is false below, a hung run also holds its concurrency group and
+    # stalls later label events on the same issue.
+    timeout-minutes: 10
     concurrency:
       group: jira-create-ticket-${{ github.event.issue.node_id }}
       cancel-in-progress: false
@@ -20,7 +25,30 @@ jobs:
         env:
           ADDED_LABEL:    ${{ github.event.label.name }}
           PROJECT_CONFIG: ${{ vars.GH_JIRA_AUTOMATION_CONFIG }}
+          SENDER_TYPE:    ${{ github.event.sender.type }}
+          SENDER_LOGIN:   ${{ github.event.sender.login }}
         run: |
+          # Ignore label events applied by automation. LOOP GUARD:
+          # jira-agent-create-gh-issue.yml creates GitHub issues for tickets that already came
+          # FROM Jira, applying their labels in the create call, so a trigger label arriving
+          # that way would push the ticket straight back into Jira as a duplicate.
+          #
+          # Today GitHub does not re-trigger workflows for GITHUB_TOKEN-caused events, which is
+          # the only reason this cannot happen. That is documented platform behaviour, not
+          # something this workflow declares, and it stops applying the moment any step in the
+          # chain uses a PAT or a GitHub App token. Check it explicitly instead.
+          #
+          # Deliberately keyed on the SENDER (who added the label), NOT on issue.user (who
+          # opened the issue). A human adding a dev-backlog trigger label to a Jira-origin
+          # issue is legitimate triage and must still work; keying on the author would block
+          # it forever. Type is used rather than a login match so GitHub Apps and other bots
+          # are covered too.
+          if [ "$SENDER_TYPE" = "Bot" ]; then
+            echo "Label was added by '$SENDER_LOGIN' ($SENDER_TYPE), not a person. Skipping."
+            echo "matched=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           if ! echo "$PROJECT_CONFIG" | jq -e . >/dev/null 2>&1; then
             echo "GH_JIRA_AUTOMATION_CONFIG is not valid JSON. Check the Actions variable value (must be strict JSON, not JSONC)." >&2
             exit 1
@@ -40,7 +68,8 @@ jobs:
           fi
       - name: Check actor authorization
         if: steps.trigger_check.outputs.matched == 'true'
-        uses: actions/github-script@v7
+        id: actor_check
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           ORG_READ_TOKEN: ${{ secrets.GH_ORG_READ_PAT }}
           ALLOWED_TEAMS:  ${{ vars.GH_JIRA_AUTOMATION_ALLOWED_TEAMS }}
@@ -59,7 +88,13 @@ jobs:
               core.setFailed('GH_ORG_READ_PAT secret is not set.');
               return;
             }
-            const teamClient = new github.constructor({ auth: process.env.ORG_READ_TOKEN });
+            // Team membership needs a token with read:org, which GITHUB_TOKEN does not have,
+            // so this needs a SECOND client authenticated as GH_ORG_READ_PAT.
+            // getOctokit is injected into the script context by github-script v8+ and is the
+            // supported way to build one. The previous `new github.constructor({ auth })`
+            // reached into @actions/github internals, which v9 explicitly calls out as
+            // unsupported (v9 is ESM-only and added getOctokit as the replacement).
+            const teamClient = getOctokit(process.env.ORG_READ_TOKEN);
             let authorized = false;
             for (const team of teams) {
               try {
@@ -76,12 +111,22 @@ jobs:
               }
             }
 
+            // An unauthorized actor is NOT a failure — the event simply is not actionable, and
+            // the remaining steps skip on this output. Failing here would spend the run's red
+            // status on a routing decision, which is how a genuine breakage (a Jira 400, an npm
+            // outage, a schema change) ends up indistinguishable from routine noise.
+            // Surfaced as a warning so the attempt is still visible in the run summary and
+            // annotations without marking the run failed. Missing configuration above IS a
+            // real failure and still calls setFailed.
+            core.setOutput('authorized', String(authorized));
             if (!authorized) {
-              core.setFailed(`🚫 ${actor} is not a member of any allowed team: ${teams.join(', ')}`);
+              core.warning(
+                `${actor} is not a member of any allowed team (${teams.join(', ')}); ` +
+                `no Jira ticket will be created for this label.`);
             }
 
       - name: Extract Jira metadata from issue labels
-        if: steps.trigger_check.outputs.matched == 'true'
+        if: steps.trigger_check.outputs.matched == 'true' && steps.actor_check.outputs.authorized == 'true'
         id: jira_meta
         env:
           LABELS:          ${{ toJson(github.event.issue.labels) }}
@@ -137,9 +182,9 @@ jobs:
           echo "✅ Resolved → project: $PROJECT, type: ${TYPE:-Story}, assignee: ${ASSIGNEE:-(none)}, sprint: ${SPRINT:-(none)}, labels: ${TRANSFER_LABELS}"
 
       - name: Check for existing Jira ticket for this project
-        if: steps.trigger_check.outputs.matched == 'true'
+        if: steps.trigger_check.outputs.matched == 'true' && steps.actor_check.outputs.authorized == 'true'
         id: check_existing
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           JIRA_PROJECT_KEY: ${{ steps.jira_meta.outputs.project }}
         with:
@@ -210,7 +255,7 @@ jobs:
             }
 
       - name: Create Jira Ticket
-        if: steps.trigger_check.outputs.matched == 'true' && steps.check_existing.outputs.already_exists == 'false'
+        if: steps.trigger_check.outputs.matched == 'true' && steps.actor_check.outputs.authorized == 'true' && steps.check_existing.outputs.already_exists == 'false'
         id: create_ticket
         env:
           JIRA_BASE_URL:    ${{ vars.JIRA_BASE_URL }}
@@ -284,7 +329,7 @@ jobs:
           echo "✅ Created Jira ticket: $JIRA_KEY"
 
       - name: Add GitHub issue link to Jira ticket
-        if: steps.trigger_check.outputs.matched == 'true' && steps.check_existing.outputs.already_exists == 'false'
+        if: steps.trigger_check.outputs.matched == 'true' && steps.actor_check.outputs.authorized == 'true' && steps.check_existing.outputs.already_exists == 'false'
         env:
           JIRA_BASE_URL:   ${{ vars.JIRA_BASE_URL }}
           JIRA_USER_EMAIL: ${{ secrets.CREATE_JIRA_TICKET_USER_EMAIL }}
@@ -317,8 +362,8 @@ jobs:
           echo "✅ Remote link added to Jira ticket"
 
       - name: Append Jira URL to issue "Jira Key" field
-        if: steps.trigger_check.outputs.matched == 'true' && steps.check_existing.outputs.already_exists == 'false'
-        uses: actions/github-script@v7
+        if: steps.trigger_check.outputs.matched == 'true' && steps.actor_check.outputs.authorized == 'true' && steps.check_existing.outputs.already_exists == 'false'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           JIRA_BASE_URL:  ${{ vars.JIRA_BASE_URL }}
           FIELD_ID:       ${{ steps.check_existing.outputs.field_id }}
@@ -346,4 +391,60 @@ jobs:
             `, { issueId: issueNodeId, fieldId, value: newValue });
 
             console.log(`✅ "Jira Key" field set to: ${newValue}`);
+
+      # Runs even when earlier steps skipped or failed, because a skip is now the NORMAL
+      # outcome here (label is not a trigger, bot-applied label, unauthorized actor, or the
+      # project already has a ticket) and a green run with no explanation is the thing that
+      # makes these workflows hard to trust. always() also means a failed run still says how
+      # far it got.
+      - name: Job summary
+        if: always()
+        env:
+          MATCHED:       ${{ steps.trigger_check.outputs.matched }}
+          PROJECT_LABEL: ${{ steps.trigger_check.outputs.project_label }}
+          AUTHORIZED:    ${{ steps.actor_check.outputs.authorized }}
+          PROJECT:       ${{ steps.jira_meta.outputs.project }}
+          ISSUE_TYPE:    ${{ steps.jira_meta.outputs.issue_type }}
+          XFER_LABELS:   ${{ steps.jira_meta.outputs.transfer_labels }}
+          ALREADY:       ${{ steps.check_existing.outputs.already_exists }}
+          EXISTING:      ${{ steps.check_existing.outputs.existing_value }}
+          JIRA_KEY:      ${{ steps.create_ticket.outputs.jira_key }}
+          JIRA_BASE_URL: ${{ vars.JIRA_BASE_URL }}
+          ADDED_LABEL:   ${{ github.event.label.name }}
+          SENDER_LOGIN:  ${{ github.event.sender.login }}
+          SENDER_TYPE:   ${{ github.event.sender.type }}
+          ISSUE_NUM:     ${{ github.event.issue.number }}
+          ISSUE_URL:     ${{ github.event.issue.html_url }}
+        run: |
+          {
+            echo "## Labelled issue → Jira dev backlog"
+            echo
+            echo "| | |"
+            echo "|---|---|"
+            echo "| GitHub issue | [#${ISSUE_NUM}](${ISSUE_URL}) |"
+            echo "| Label added | \`${ADDED_LABEL}\` by \`${SENDER_LOGIN}\` (${SENDER_TYPE}) |"
+            if [ "$MATCHED" != "true" ]; then
+              if [ "$SENDER_TYPE" = "Bot" ]; then
+                echo "| Outcome | **skipped** — label was applied by automation, not a person |"
+              else
+                echo "| Outcome | **skipped** — \`${ADDED_LABEL}\` is not a configured project trigger |"
+              fi
+            elif [ "$AUTHORIZED" != "true" ]; then
+              echo "| Target project | \`${PROJECT_LABEL}\` |"
+              echo "| Outcome | **skipped** — \`${SENDER_LOGIN}\` is not in an allowed team |"
+            elif [ "$ALREADY" = "true" ]; then
+              echo "| Target project | \`${PROJECT}\` |"
+              echo "| Existing linkage | \`${EXISTING}\` |"
+              echo "| Outcome | **skipped** — \`${PROJECT}\` already has a ticket for this issue |"
+            elif [ -n "$JIRA_KEY" ]; then
+              echo "| Jira ticket | [${JIRA_KEY}](${JIRA_BASE_URL}/browse/${JIRA_KEY}) |"
+              echo "| Target project | \`${PROJECT}\` |"
+              echo "| Issue type | ${ISSUE_TYPE:-(none)} |"
+              echo "| Labels transferred | \`${XFER_LABELS:-[]}\` |"
+              echo "| Existing linkage before | \`${EXISTING:-(none)}\` |"
+              echo "| Outcome | **created** |"
+            else
+              echo "| Outcome | **no ticket created** — the trigger matched and the actor was authorized, so a later step failed; see step log |"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
 

--- a/.github/workflows/github-to-jira-dev-backlog.yml
+++ b/.github/workflows/github-to-jira-dev-backlog.yml
@@ -6,6 +6,15 @@ on:
 
 permissions:
   issues: write
+
+# Hard-coded rather than a repo variable. It is a public URL, not a secret, and the Ed-Fi Jira
+# site is not going to differ between the repos this workflow runs in - so making it
+# configurable only added a per-repo value to provision and get wrong. A site migration would
+# be a visible one-line diff here instead of an invisible settings change.
+# Declared once at workflow level, so every step below inherits it.
+env:
+  JIRA_BASE_URL: https://edfi.atlassian.net
+
 jobs:
   github-to-jira-dev-backlog:
     # Run on every label event — the first step determines if this label is a configured trigger
@@ -258,7 +267,6 @@ jobs:
         if: steps.trigger_check.outputs.matched == 'true' && steps.actor_check.outputs.authorized == 'true' && steps.check_existing.outputs.already_exists == 'false'
         id: create_ticket
         env:
-          JIRA_BASE_URL:    ${{ vars.JIRA_BASE_URL }}
           JIRA_PROJECT_KEY: ${{ steps.jira_meta.outputs.project }}
           JIRA_ISSUE_TYPE:  ${{ steps.jira_meta.outputs.issue_type }}
           JIRA_ASSIGNEE_ID: ${{ steps.jira_meta.outputs.assignee }}
@@ -331,7 +339,6 @@ jobs:
       - name: Add GitHub issue link to Jira ticket
         if: steps.trigger_check.outputs.matched == 'true' && steps.actor_check.outputs.authorized == 'true' && steps.check_existing.outputs.already_exists == 'false'
         env:
-          JIRA_BASE_URL:   ${{ vars.JIRA_BASE_URL }}
           JIRA_USER_EMAIL: ${{ secrets.CREATE_JIRA_TICKET_USER_EMAIL }}
           JIRA_API_TOKEN:  ${{ secrets.CREATE_JIRA_TICKET_PAT }}
           JIRA_KEY:        ${{ steps.create_ticket.outputs.jira_key }}
@@ -365,7 +372,6 @@ jobs:
         if: steps.trigger_check.outputs.matched == 'true' && steps.actor_check.outputs.authorized == 'true' && steps.check_existing.outputs.already_exists == 'false'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
-          JIRA_BASE_URL:  ${{ vars.JIRA_BASE_URL }}
           FIELD_ID:       ${{ steps.check_existing.outputs.field_id }}
           EXISTING_VALUE: ${{ steps.check_existing.outputs.existing_value }}
         with:
@@ -409,7 +415,6 @@ jobs:
           ALREADY:       ${{ steps.check_existing.outputs.already_exists }}
           EXISTING:      ${{ steps.check_existing.outputs.existing_value }}
           JIRA_KEY:      ${{ steps.create_ticket.outputs.jira_key }}
-          JIRA_BASE_URL: ${{ vars.JIRA_BASE_URL }}
           ADDED_LABEL:   ${{ github.event.label.name }}
           SENDER_LOGIN:  ${{ github.event.sender.login }}
           SENDER_TYPE:   ${{ github.event.sender.type }}

--- a/.github/workflows/github-to-jira-dev-backlog.yml
+++ b/.github/workflows/github-to-jira-dev-backlog.yml
@@ -332,7 +332,24 @@ jobs:
             --header "Content-Type: application/json" \
             --data "$PAYLOAD")
 
-          JIRA_KEY=$(echo "$RESPONSE" | jq -r '.key')
+          JIRA_KEY=$(echo "$RESPONSE" | jq -r '.key // empty')
+
+          # Jira answered 2xx here - curl --fail would have aborted otherwise - but a success
+          # payload without a .key would leave this empty (or the string "null" without the
+          # `// empty` guard) and the workflow would carry on regardless: POST to
+          # /issue/null/remotelink, then append ".../browse/null" to the "Jira Key" field. That
+          # field is the linkage between the two systems, so a broken entry is worse than a
+          # failure - it looks correct and silently is not, and it is appended, so it persists.
+          # Fail here instead.
+          #
+          # The payload is echoed because --silent --fail discards response bodies, so this is
+          # otherwise the one place a malformed response leaves no diagnostic trace at all.
+          if [ -z "$JIRA_KEY" ]; then
+            echo "Jira returned success but no issue key. Response body:" >&2
+            echo "$RESPONSE" >&2
+            exit 1
+          fi
+
           echo "jira_key=$JIRA_KEY" >> "$GITHUB_OUTPUT"
           echo "✅ Created Jira ticket: $JIRA_KEY"
 

--- a/.github/workflows/github-to-jira-dev-backlog.yml
+++ b/.github/workflows/github-to-jira-dev-backlog.yml
@@ -115,8 +115,30 @@ jobs:
                 authorized = true;
                 console.log(`✅ ${actor} is authorized via team "${team}".`);
                 break;
-              } catch {
-                // not in this team, try the next
+              } catch (err) {
+                // 404 is the expected "this user is not in this team" answer, so move on.
+                //
+                // Anything else must FAIL rather than be read as "not in team": 401 or 403 for
+                // an expired GH_ORG_READ_PAT or one missing read:org, plus 5xx and rate limits.
+                // Swallowing those used to be merely confusing, because an unauthorized actor
+                // failed the run anyway. Now that an unauthorized actor is a green-run skip, a
+                // broken credential would instead report a PERSON as not being in a team —
+                // a false statement about someone — while the automation quietly stopped
+                // working and every run still looked fine.
+                //
+                // This mirrors the org-membership check in github-to-jira-for-support-triage.yml,
+                // which treats only 404 as a definitive negative and refuses to guess otherwise.
+                //
+                // Known limitation: a mistyped team slug in GH_JIRA_AUTOMATION_ALLOWED_TEAMS
+                // also returns 404 and is indistinguishable from a genuine non-member, so a
+                // typo reads as "not authorized" rather than as misconfiguration.
+                if (err.status !== 404) {
+                  core.setFailed(
+                    `Could not determine whether ${actor} is in team "${team}" ` +
+                    `(HTTP ${err.status}: ${err.message}). Refusing to treat this as ` +
+                    `"not a member" — check GH_ORG_READ_PAT is valid and has read:org.`);
+                  return;
+                }
               }
             }
 
@@ -423,6 +445,18 @@ jobs:
       - name: Job summary
         if: always()
         env:
+          # Step OUTCOMES, not just outputs. A step that fails before writing its output leaves
+          # that output empty, which the skip branches below would otherwise read as a negative
+          # answer — reporting invalid config as "not a configured trigger", or a missing
+          # GH_ORG_READ_PAT as "<person> is not in an allowed team". Naming a person for what is
+          # a configuration fault is the worst version of that. Outcomes are checked FIRST so a
+          # failure is never dressed up as a routing decision, and this covers any future
+          # failure path automatically rather than only the ones instrumented today.
+          TRIGGER_OUTCOME:  ${{ steps.trigger_check.outcome }}
+          ACTOR_OUTCOME:    ${{ steps.actor_check.outcome }}
+          META_OUTCOME:     ${{ steps.jira_meta.outcome }}
+          EXISTING_OUTCOME: ${{ steps.check_existing.outcome }}
+          CREATE_OUTCOME:   ${{ steps.create_ticket.outcome }}
           MATCHED:       ${{ steps.trigger_check.outputs.matched }}
           PROJECT_LABEL: ${{ steps.trigger_check.outputs.project_label }}
           AUTHORIZED:    ${{ steps.actor_check.outputs.authorized }}
@@ -445,7 +479,17 @@ jobs:
             echo "|---|---|"
             echo "| GitHub issue | [#${ISSUE_NUM}](${ISSUE_URL}) |"
             echo "| Label added | \`${ADDED_LABEL}\` by \`${SENDER_LOGIN}\` (${SENDER_TYPE}) |"
-            if [ "$MATCHED" != "true" ]; then
+            if [ "$TRIGGER_OUTCOME" = "failure" ]; then
+              echo "| Outcome | **failed** — the trigger check errored before deciding; \`GH_JIRA_AUTOMATION_CONFIG\` is most likely not valid JSON. See the step log. |"
+            elif [ "$ACTOR_OUTCOME" = "failure" ]; then
+              echo "| Outcome | **failed** — authorization could not be determined. Either \`GH_JIRA_AUTOMATION_ALLOWED_TEAMS\` or \`GH_ORG_READ_PAT\` is missing, or the team lookup itself failed. This is **not** a statement that \`${SENDER_LOGIN}\` lacks access. See the step log. |"
+            elif [ "$META_OUTCOME" = "failure" ]; then
+              echo "| Outcome | **failed** — could not resolve the Jira project or issue type; check \`GH_JIRA_AUTOMATION_CONFIG\` and \`JIRA_GH_TYPE_MAP\`. See the step log. |"
+            elif [ "$EXISTING_OUTCOME" = "failure" ]; then
+              echo "| Outcome | **failed** — could not read the \`Jira Key\` issue field to check for an existing ticket. See the step log. |"
+            elif [ "$CREATE_OUTCOME" = "failure" ]; then
+              echo "| Outcome | **failed** — Jira ticket creation failed. See the step log for the response body. |"
+            elif [ "$MATCHED" != "true" ]; then
               if [ "$SENDER_TYPE" = "Bot" ]; then
                 echo "| Outcome | **skipped** — label was applied by automation, not a person |"
               else


### PR DESCRIPTION
Ports hardening for `github-to-jira-dev-backlog.yml` from `Ed-Fi-Alliance-OSS/Automation-Testing`, where it was reviewed and tested alongside the two sibling workflows.

Tracked as **[AI-194](https://edfi.atlassian.net/browse/AI-194)**, follow-up to **[AI-142](https://edfi.atlassian.net/browse/AI-142)** (the original build, merged here as #114).

## What changes

**Action pinning + version bump.** All three `actions/github-script` references were on the mutable `@v7` tag, so the code actually executed was resolved at run time rather than fixed by this repo's commit. Now pinned to a commit SHA with the version in a trailing comment, per Ed-Fi convention, at v9.0.0 (`3a2844b7e9c422d3c10d287c895573f7108da1b3`). The v9.0.0 tag is *annotated*, so the pin is the dereferenced commit SHA, not the tag-object SHA. v9 runs on `node24`, which also clears the Node 20 deprecation warning.

**Secondary Octokit client rewritten — the reason the pin could not be applied as-is.** The actor-authorization step built its client with `new github.constructor({ auth: ... })`, reaching into `@actions/github` internals. v9 is ESM-only and explicitly calls that out as needing updating, having added an injected `getOctokit` as the replacement:

```diff
- const teamClient = new github.constructor({ auth: process.env.ORG_READ_TOKEN });
+ const teamClient = getOctokit(process.env.ORG_READ_TOKEN);
```

The second client is genuinely required: reading team membership needs `read:org`, which `GITHUB_TOKEN` does not carry, hence `GH_ORG_READ_PAT`.

**`timeout-minutes: 10`** — the default is 360. This job has more hang surface than its siblings (a runtime `npm install` plus two curls to Jira), and because `cancel-in-progress: false`, a hung run also holds its concurrency group and stalls later label events on the same issue.

**Loop guard against automation-applied labels.** A sibling workflow creates GitHub issues for tickets that already came *from* Jira, applying labels in the create call — so a trigger label arriving that way would push the ticket straight back into Jira as a duplicate. Nothing declared prevented that; it was prevented only by GitHub not re-triggering workflows for `GITHUB_TOKEN`-caused events, which is documented platform behaviour with no exception for `issues` events, and which stops applying the moment any step in the chain uses a PAT or GitHub App token.

Keyed on the **sender** (who added the label), *not* `issue.user` (who opened it). A human adding a dev-backlog trigger label to a Jira-origin issue is legitimate triage and must keep working; keying on the author would block that permanently. Uses `sender.type` rather than a login match, so GitHub Apps and other bots are covered.

**Non-actionable events now skip on a green run instead of failing.** Previously a failed run meant two unrelated things — "something broke" and "this event was not for me". Once the second is routine, the first becomes invisible: a Jira 400, an npm outage or a schema change arrives looking exactly like noise. An unauthorized actor now publishes an `authorized` output and surfaces the attempt as a warning annotation, with the five downstream steps gated on it. Genuine misconfiguration still fails the run — missing `GH_JIRA_AUTOMATION_ALLOWED_TEAMS` or `GH_ORG_READ_PAT`, or a missing `Jira Key` issue field.

**Distinguishable names.** The job key `create-jira-ticket` was shared with a sibling workflow, and that key is what renders as the job name in the Actions UI, so run views could not be told apart. Now `Labelled issue → Jira dev backlog` with job `github-to-jira-dev-backlog`. **Filename and numeric workflow ID are unchanged**, so dispatch by file or ID is unaffected.

**Job summary** with `if: always()`, so it is produced even when steps skip or fail. It names *which* condition caused a skip — non-trigger label, bot-applied label, unauthorized actor, or project already ticketed — and distinguishes "skipped deliberately" from "acted, then a later step failed". That matters because skipping is now the normal outcome, and a green run with no explanation is what made this hard to trust.

## What does NOT change

Per-project dedupe still compares the stored project prefix against the target project, and that is deliberate. This workflow writes the `Jira Key` field, which is multi-project and comma-appended, so project-scoped dedupe is the feature. (The support-triage sibling was changed to a presence check because `Jira Support Key` is single-purpose — the same change here would break appending across projects.)

## Verification

No unit-test harness exists for these workflows, so the embedded scripts were extracted and run against stubbed GitHub/Jira clients:

- **Actor authorization**, 5 cases — in the first allowed team, in a later one, in none, and each missing-configuration path. This step fails **closed**, so an error here would reject every trigger label; worth reviewer attention.
- **Trigger / loop-guard control flow**, 4 cases — bot + trigger label, bot + other label, human + trigger label, human + other label. All exit 0, and human + trigger label still resolves the project correctly.
- **Job summary**, 6 branches, each producing the intended outcome line.
- Workflow parses under a real YAML parser; every `uses:` is SHA-pinned with a version comment.

**Not verified:** v9's actual Octokit client behaviour, because the harness stubs the client — `getOctokit` is the v9-sensitive spot and only a real run proves it. The `jq` filters were shimmed locally rather than executed, though they are unchanged from the version currently live here.

## Reviewer notes

- **No new secrets or variables are required, and one variable is retired.** `GH_ORG_READ_PAT` was already in use by this workflow. `JIRA_BASE_URL` is now a hard-coded constant in the workflow-level `env:` rather than a repo variable — it is a public URL, not a secret, and does not differ between the repos this runs in, so configurability only meant another per-repo value to provision. The remaining three (`GH_JIRA_AUTOMATION_CONFIG`, `GH_JIRA_AUTOMATION_ALLOWED_TEAMS`, `JIRA_GH_TYPE_MAP`) demonstrably already resolve here — the whole job is gated on `vars.GH_JIRA_AUTOMATION_CONFIG != ''` and it runs.
- The behavioural change most worth a second opinion is unauthorized actors no longer failing the run. If you would rather an unauthorized attempt stay a red run, that is a one-line revert.
- Known issues deliberately left for separate work, listed in AI-194: a `${{ }}` value interpolated into JavaScript source, an unchecked `jq -r '.key'` that can write `.../browse/null`, `curl --fail` discarding Jira error bodies, and the silent Markdown-to-ADF fallback (AI-171).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[AI-194]: https://edfi.atlassian.net/browse/AI-194?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AI-142]: https://edfi.atlassian.net/browse/AI-142?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ